### PR TITLE
Fix/dispatch function clause

### DIFF
--- a/lib/nostrum/shard/dispatch.ex
+++ b/lib/nostrum/shard/dispatch.ex
@@ -199,8 +199,8 @@ defmodule Nostrum.Shard.Dispatch do
   def handle_event(:VOICE_SERVER_UPDATE = event, p, state),
     do: {event, p, state}
 
-  def handle_event(event, p, _state, _pid) do
+  def handle_event(event, p, state) do
     Logger.warn "UNHANDLED GATEWAY DISPATCH EVENT TYPE: #{event}, #{inspect p}"
-    p
+    {event, p, state}
   end
 end

--- a/lib/nostrum/shard/dispatch.ex
+++ b/lib/nostrum/shard/dispatch.ex
@@ -108,7 +108,7 @@ defmodule Nostrum.Shard.Dispatch do
 
   def handle_event(:GUILD_DELETE = event, p, state) do
     :ets.delete(:guild_shard_map, p.id)
-    {event, {GuildServer.delete(p.id), p.unavailable}, state}
+    {event, {GuildServer.delete(p.id), Map.get(p, :unavailable, false)}, state}
   end
 
   def handle_event(:GUILD_EMOJIS_UPDATE = event, p, state),


### PR DESCRIPTION
## What
Since the *else* match pattern had different arity than other `handle_event` functions, events not handled by other functions became an error and thus Nostrum had terminated. This fixes it.
This also fixes the first problem mentioned in https://github.com/Kraigie/nostrum/issues/24 (The kicking prioblem.)

This doesn't do anything about the cleanup which I mentioned in the issue above.